### PR TITLE
Enable cross-platform writes of las files

### DIFF
--- a/func_dlis_to_las.py
+++ b/func_dlis_to_las.py
@@ -116,7 +116,21 @@ def convert_dlis_to_las(filepath, output_folder_location, null=-999.25):
                 las.params['VERSION'] = lasio.HeaderItem('VERSION', value=origin.version)
                 las.params['LINEAGE'] = lasio.HeaderItem('LINEAGE', value="Python-converted from DLIS")
                 las.params['ORFILE'] = lasio.HeaderItem('ORFILE', value=filepath)
-                las.write(output_folder_location + "\\" + filename + "_" + 'converted_with_python_' + str(frame_count) + '.las', version=2)
+
+                # -----------------------------------------------------------------------
+                # Write file
+                # -----------------------------------------------------------------------
+                outfile = filename + "_" + "converted_with_python_" + str(frame_count) + ".las"
+                outpath = os.path.join(output_folder_location, outfile)
+
+                if not os.path.exists(output_folder_location):
+                    print("Making output directory: [{}]\n".format(output_folder_location))
+                    os.makedirs(output_folder_location)
+
+                print("Writing: [{}]\n".format(outpath))
+                las.write(outpath, version=2)
+
+
             print("number of frames: " + str(frame_count) + ": this is the number of .las files created")
             print("embedded_files: " + str(len(embedded_files)))
             print("This file has " + str(len(origins)) + " metadata headers.  This code has used the first.")


### PR DESCRIPTION
This pull request changes func_dlis_to_las.py to enable writing the `.las` files on windows,  linux, and other platforms.

I didn't make this change in the Jupyter files.  Let me know if I should make the change there too.

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC