### PR TITLE
Fix lascheck report of invalid data index channel

### DIFF
--- a/func_dlis_to_las.py
+++ b/func_dlis_to_las.py
@@ -89,10 +89,13 @@ def convert_dlis_to_las(filepath, output_folder_location, null=-999.25):
                 print(len(las_longs))
                 curve_df = df_column_uniquify(curve_df)
                 curves_name = list(curve_df.columns.values)
+                reordered_curves_name = move_valid_index_to_first_col(curves_name)
+                curve_df = curve_df.reindex(reordered_curves_name, axis=1)
+
                 print(len(curves_name))
 
                 # we will take the first curve in the frame as the index.
-                curve_df = curve_df.set_index(curves_name[0])
+                curve_df = curve_df.set_index(reordered_curves_name[0])
                 # write the pandas data to the las file
                 las.set_data(curve_df)
                 # write the curve metadata from our three lists.
@@ -135,3 +138,18 @@ def convert_dlis_to_las(filepath, output_folder_location, null=-999.25):
             print("embedded_files: " + str(len(embedded_files)))
             print("This file has " + str(len(origins)) + " metadata headers.  This code has used the first.")
             print(object_warning)
+
+
+def move_valid_index_to_first_col(curves_name):
+    idx_col = 0
+    for curve in ['DEPT', 'DEPTH', 'TIME', 'INDEX']:
+        if curve in curves_name:
+            idx_col = curves_name.index(curve)
+            break
+
+    reordered_curves_name = curves_name[idx_col:idx_col+1]
+    reordered_curves_name.extend(curves_name[:idx_col])
+    reordered_curves_name.extend(curves_name[idx_col+1:])
+
+    return reordered_curves_name
+

--- a/tests/test_curve_read.py
+++ b/tests/test_curve_read.py
@@ -3,6 +3,10 @@ dlisio.set_encodings(['latin1'])
 import os
 import sys
 
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from func_dlis_to_las import move_valid_index_to_first_col
+
 def test_curve_read():
     root = os.path.dirname( __file__ )
     file = 'data/COP_Pharos-1__VISION Service_CUSTOMER_482.11-5220.00mMD.dlis'
@@ -14,3 +18,10 @@ def test_curve_read():
                 depth_array = channel.curves()
                 print(len(depth_array))
     assert len(depth_array) > 0
+
+
+def test_index_is_first_col():
+    curves_name = ['TDEP', 'DEPTH']
+    reordered_curves = move_valid_index_to_first_col(curves_name)
+    assert reordered_curves[0] == 'DEPTH'
+    assert reordered_curves[1] == 'TDEP'


### PR DESCRIPTION
#### Description:
Reorder curve_df so that a valid Las2 index channel is the first data
column.

Running a dlis-to-las generated las file through lascheck reports an 'Invalid index
mnemonic'The only valid mnemonics for the index channel are DEPT, DEPTH,
TIME, or INDEX.’]. This is for Las 2.0 spec.

This may help other tools read the Dlis-to-Las las files.

#### To reproduce:
```bash
pip install lascheck
```

```python
import lascheck
myfile = 'dlis-to-las.las'
print('-------------------------------------------')
las = lascheck.read(myfile)
print('-------------------------------------------')
print(myfile, las.check_conformity())
print('-------------------------------------------')
print(las.get_non_conformities())
```

Result
```
['Invalid index mnemonic. The only valid mnemonics for the index channel are DEPT, DEPTH, TIME, or INDEX.']
```

#### Test Results 
All tests pass

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.

Thank you,
DC


