### PR TITLE
Revert the commits for modifying the data index

### DIFF
--- a/func_dlis_to_las.py
+++ b/func_dlis_to_las.py
@@ -52,18 +52,14 @@ def convert_dlis_to_las(filepath, output_folder_location, null=-999.25):
                 )
 
                 curves_name = list(curve_df.columns.values)
-                reordered_curves_name = move_valid_index_to_first_col(curves_name)
-                curve_df = curve_df.reindex(reordered_curves_name, axis=1)
-
                 print(len(curves_name))
 
                 # we will take the first curve in the frame as the index.
-                curve_df = curve_df.set_index(reordered_curves_name[0])
+                curve_df = curve_df.set_index(curves_name[0])
 
                 # -----------------------------------------------------------------------
                 # Create las file
                 # -----------------------------------------------------------------------
-
                 las = create_las(
                     curve_df, curves_name, origin, las_units, las_longs, null, filepath
                 )
@@ -77,20 +73,6 @@ def convert_dlis_to_las(filepath, output_folder_location, null=-999.25):
             print("embedded_files: " + str(len(embedded_files)))
             print("This file has " + str(len(origins)) + " metadata headers.  This code has used the first.")
             print(object_warning)
-
-
-def move_valid_index_to_first_col(curves_name):
-    idx_col = 0
-    for curve in ['DEPT', 'DEPTH', 'TIME', 'INDEX']:
-        if curve in curves_name:
-            idx_col = curves_name.index(curve)
-            break
-
-    reordered_curves_name = curves_name[idx_col:idx_col+1]
-    reordered_curves_name.extend(curves_name[:idx_col])
-    reordered_curves_name.extend(curves_name[idx_col+1:])
-
-    return reordered_curves_name
 
 
 def process_curve_info(channel_data):

--- a/tests/test_curve_read.py
+++ b/tests/test_curve_read.py
@@ -9,10 +9,8 @@ dlisio.set_encodings(["latin1"])
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from func_dlis_to_las import (
-    move_valid_index_to_first_col,
-    process_curve_info
-)
+# Follows sys.path.insert so that func_dlis_to_las is found
+from func_dlis_to_las import process_curve_info
 
 
 def test_curve_read():
@@ -26,13 +24,6 @@ def test_curve_read():
                 depth_array = channel.curves()
                 print(len(depth_array))
     assert len(depth_array) > 0
-
-
-def test_index_is_first_col():
-    curves_name = ["TDEP", "DEPTH"]
-    reordered_curves = move_valid_index_to_first_col(curves_name)
-    assert reordered_curves[0] == "DEPTH"
-    assert reordered_curves[1] == "TDEP"
 
 
 def test_process_curve_info():


### PR DESCRIPTION
#### Description:

This pull-request addresses issue #5 Revisit index re-assignment when writing LAS file. It reverts commits related to index re-assignment.  

The thinking for this pull-request is that it is better to accept dlisio's index curve and not make the assumption that another channel should be the index based on its name.  

While the LAS 2.0 specification does indicate that the index curve should be named one of: 'DEPT', 'DEPTH', 'TIME', 'INDEX', many real world las files use a different name for the index.  

A possible better solution is to give the users an option to rename the index curve. In that scenario the `rename` would need to be checked whether it already exists as the name of another curve.   Consideration would need to be given to whether the rename should apply to all las files generated from a given Dlisio input or only specific ones. 

 As an alternate solution users can use the Lasio tool to read las files with alternative index names. The index can be renamed within Lasio if the user needs to las files to specifically meet the the LAS 2.0 spec.


#### Reverted commits:
a20d419 Merge pull request #3 from
eecec92 Add test for new move_valid_index_to_first_col()
67dc925 Fix lascheck report of invalid data index channel

#### Tests:

All tests pass

```
Name                          Stmts   Miss  Cover
-------------------------------------------------
func_dlis_to_las.py             111     67    40%
```

Let me know if this change could be accepted (or rejected) or
needs some additional changes before being approved and merged.


Thank you,
DC

